### PR TITLE
Automatically switch to TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.bcd
+*.var
+*.pfx
+output.crt
+output-key.key


### PR DESCRIPTION
We encountered a SCCM installation that required mutual authentication using client certificates. The error message did not provide much information. But we figured out, that by converting the pfx and setting the TLS variable we were able to request the information from the server. To ease this process I added code that automatically generates the certificate files from the pfx and switches to mutual TLS in case the HTTP connection fails.

In addition I fixed some illegal quoting that caused warnings.