### PR TITLE
fix encrypted key usage for aes256 with blank password

### DIFF
--- a/pxethief.py
+++ b/pxethief.py
@@ -537,7 +537,11 @@ def use_encrypted_key(encrypted_key=None, media_file_path=None, encrypted_bytes=
 
     key = media_crypto.aes_des_key_derivation(key_data) # Derive key to decrypt key bytes in the DHCP response
 
-    var_file_key = (media_crypto.aes128_decrypt_raw(encrypted_bytes[:16],key[:16])[:10]) # 10 byte output, can be padded (appended) with 0s to get to 16 struct.unpack('10c',var_file_key)
+    var_file_key = None
+    if "aes256" in media_crypto.read_media_variable_file_header(media_file_path)[0:6]:
+        var_file_key = (media_crypto.aes256_decrypt_raw(encrypted_bytes[:16],key[:32])[:10])
+    else:
+        var_file_key = (media_crypto.aes128_decrypt_raw(encrypted_bytes[:16],key[:16])[:10]) #10 byte output, can be padded (appended) with 0s to get to 16 struct.unpack('10c',var_file_key)
     
     #Perform bit extension
     LEADING_BIT_MASK =  b'\x80'


### PR DESCRIPTION
So have noticed on two separate occasions when decrypting a VAR file without a password set, it seems the file is encrypted with AES265. However, currently the behavior is to decrypt with AES128. Not sure if this is a new default with SCCM 2509 (both environments I have confirmed this working in are version 2509 for SCCM) or some other configuration change.  Essentially this pull, checks the header first and if it is AES256 calls the AES256 Decrypt Raw function and if that header is not there goes back to using the previous AES128 Decrypt Raw function. Let me know if there is any other changes I should make. Right now this seems to be working in my lab as well, and can test some more things if needed.  